### PR TITLE
Small improvements to server tasks

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "log-symbols": "1.0.2",
     "lost": "8.0.0",
     "main-bower-files": "2.13.1",
+    "morgan": "^1.8.2",
     "postcss-calc": "5.3.1",
     "postcss-clearfix": "1.0.0",
     "postcss-color-function": "3.0.0",

--- a/tools/servers/server.spa.js
+++ b/tools/servers/server.spa.js
@@ -14,6 +14,10 @@ module.exports = function configureServer(config, app) {
     });
   }
 
+  if (_.get(config, 'server.options.logs')) {
+    app.use(require('morgan')('dev'));
+  }
+
   if (_.get(config, 'server.options.gzip')) {
     app.use(require('compression')());
   }

--- a/tools/tasks/tasks.serve.js
+++ b/tools/tasks/tasks.serve.js
@@ -30,7 +30,7 @@ module.exports = function setUpTasks(gulp) {
     );
   }, {
     description: 'Start a local server for this project and view it in Chrome.',
-    notes: ['The task will finish once the server has started, but the server will run in the background until the `stop-server` task is called.'],
+    notes: ['The task will finish once the server has started, but the server will run in the background until the `serve-stop` task is called.'],
     category: 'main',
     weight: 2
   });
@@ -74,7 +74,7 @@ module.exports = function setUpTasks(gulp) {
     serverConfig.instance.listen(serverConfig.port, done);
   }, {
     description: 'Start a local server for this project.',
-    notes: ['The task will finish once the server has started, but the server will run in the background until the `stop-server` task is called.'],
+    notes: ['The task will finish once the server has started, but the server will run in the background until the `serve-stop` task is called.'],
     category: 'serve'
   });
 

--- a/tools/tasks/tasks.serve.js
+++ b/tools/tasks/tasks.serve.js
@@ -11,14 +11,6 @@ module.exports = function setUpTasks(gulp) {
     return;
   }
 
-  if (!serverConfig.fullURL) {
-    serverConfig.fullURL = URI.serialize({
-      scheme: serverConfig.ssl ? 'https' : 'http',
-      host: serverConfig.hostname || 'localhost',
-      port: serverConfig.port || 9000
-    });
-  }
-
   runSequence = runSequence.use(gulp);
 
   // Main serve task:
@@ -89,7 +81,17 @@ module.exports = function setUpTasks(gulp) {
   });
 
   gulp.task('serve-load', function serveLoadTask() {
-    return chromeLoad(serverConfig.fullURL);
+    var loadURL = serverConfig.loadURL;
+
+    if (!loadURL) {
+      loadURL = URI.serialize({
+        scheme: serverConfig.ssl ? 'https' : 'http',
+        host: serverConfig.hostname || 'localhost',
+        port: serverConfig.port || 9000
+      });
+    }
+
+    return chromeLoad(loadURL);
   }, {
     description: 'Reload existing Chrome tabs that are pointing to the local server, or open a new tab if none exists.',
     category: 'serve'


### PR DESCRIPTION
This PR includes a few small improvements to servers and `gulp serve-` tasks:

- The SPA server now includes [`morgan`](https://github.com/expressjs/morgan) for logging if you set the `server.options.logs` option to `true`.
- The `server.fullURL` option has been discontinued in favor of the `server.loadURL` option, which controls which Chrome tabs are auto-reloaded when the `gulp serve-load` task is run. This URL is also no longer pre-calculated.