### PR TITLE
Edits `rc.htmlhint.json` to allow `viewBox` attribute to be camel case

### DIFF
--- a/runcoms/rc.htmlhint.json
+++ b/runcoms/rc.htmlhint.json
@@ -1,5 +1,5 @@
 {
-  "attr-lowercase": true,
+  "attr-lowercase": ["viewBox"],
   "attr-no-duplication": true,
   "attr-unsafe-chars": true,
   "attr-value-double-quotes": true,


### PR DESCRIPTION
This PR edits the `rc.htmlhint.json` file to ignore `viewBox` so it can be typed camel case. https://github.com/yaniswang/HTMLHint/wiki/Attr-lowercase