### PR TITLE
Update external getter

### DIFF
--- a/tools/gulp-get-ext.js
+++ b/tools/gulp-get-ext.js
@@ -15,7 +15,7 @@ module.exports = {
             return require('main-npm-files')('**/*.*', _.defaultsDeep({
               pkgJson: _.get(extOptions, 'json', 'package.json'),
               nodeModules: _.get(extOptions, 'modules', 'node_modules'),
-              onlyMain: true
+              onlyMain: false
             }, options));
 
           } else {


### PR DESCRIPTION
The `gulp-get-ext.js` file has been updated so that any npm external gets accepts things other than just a main attribute. This is to allow npm to also receive css and html though the npm `files` attribute`.