### PR TITLE
Perf improvements

### DIFF
--- a/tools/pipelines/pipeline.css.js
+++ b/tools/pipelines/pipeline.css.js
@@ -83,7 +83,7 @@ module.exports = function setupCSSPipeline(gulp) {
               transform: function (fileContents) {
                   // This allows us to use //-style comments in imported files, since
                   // PostCSS-import doesn't allow non-css syntaxes in its parser
-                  return fileContents.replace(/\/\/\s(.*)\n/g, '/* $1 */\n');
+                  return fileContents.replace(/\/\/\s?(.*)\n/g, '/* $1 */\n');
                 },
               resolve: function (id, baseDir, options) {
                   var files,

--- a/tools/pipelines/pipeline.css.js
+++ b/tools/pipelines/pipeline.css.js
@@ -87,7 +87,6 @@ module.exports = function setupCSSPipeline(gulp) {
                 },
               resolve: function (id, baseDir, options) {
                   var files,
-                      pattern = id,
                       globOptions = {
                           cwd: options.path[0],
                           nosort: true
@@ -102,11 +101,12 @@ module.exports = function setupCSSPipeline(gulp) {
                   extSearch = /^(.+):(.+)$/.exec(id);
 
                   if (!!extSearch) {
-                    pattern = extSearch[2];
                     globOptions.cwd = path.join(options.root, _.get(gulp, 'webToolsConfig.ext.modules', 'bower_components'), extSearch[1]);
-                  }
 
-                  files = glob.sync(path.join('**', pattern), globOptions);
+                    files = glob.sync(extSearch[2], globOptions);
+                  } else {
+                    files = glob.sync(path.join('**', id), globOptions);
+                  }
 
                   if (files.length) {
                     files = _.map(files, function addRoot(filepath) {

--- a/tools/tasks/tasks.watch.js
+++ b/tools/tasks/tasks.watch.js
@@ -75,7 +75,7 @@ module.exports = function setUpTasks(gulp) {
 
     gulp.task('watch-ext', function watchExtTask() {
       // Pass follow:true here to ensure symlinks are followed (for `bower link`ed components)
-      gulp.watch(extFiles, {follow: true}, function onChange() {
+      gulp.watch(extFiles, {debounceDelay: 200, follow: true}, function onChange() {
         var tasks = [],
             buildTask = 'build-ext';
 


### PR DESCRIPTION
This PR brings a number of performance improvements to web-tools, large and small.

### Large: CSS imports
The import behavior in the CSS pipeline has changed. Previously a globstar was used when importing both internal and external, allowing statements like `import 'app.vars.css';` (internal) and `import 'web-shared:component.button.vars.css';` (external). As it turns out, the presence of a globstar makes the latter case massively slow when used with symlinked external dependencies, which we frequently do when developing on `web-shared` and `web-dashboard` simultaneously.

After trying out a few different options, it seems like the best thing to do here is just disallow globstars for importing external dependencies. This ends up being a breaking change, as it requires imports that previously only referenced a filename to be updated to reference a full path, but I think this is a small price to pay for the ~3x speed improvement I'm seeing in rebuilds when watching a project and one of its linked dependencies at the same time.

### Small: Debouncing watch events in the `watch-ext` task

I've also added a `debounceDelay: 200` option to watches for external assets, to hopefully reduce thrashing if multiple linked files are rebuilt at once.

### Not even really a perf fix: Comments in imported CSS files

Finally, I fixed a bug that I noticed in our code that was handling comments in imported CSS files. We were not handling inline `//` comments properly if there wasn't a space immediately after the double-slashes.