### PR TITLE
Removes disallowSpacesInsideObjectBrackets from jscs

### DIFF
--- a/runcoms/rc.jscs.json
+++ b/runcoms/rc.jscs.json
@@ -15,7 +15,6 @@
       "beforeOpeningRoundBrace": true
   },
   "disallowSpacesInsideArrayBrackets": true,
-  "disallowSpacesInsideObjectBrackets": true,
   "disallowSpacesInsideParentheses": {
     "only": [
       "{", "}"


### PR DESCRIPTION
This PR removes the `disallowSpacesInsideObjectBrackets` from our `jscs` rules. Now that we are using es6, I think including spaces is cleaner and easier to read. When destructing for example:

```
const propsToPass = {
  prop1: 10,
  prop2: 20
};


// With spaces
$scope.addProps = ({ prop1, prop2 }) => {
  return prop1 + prop2;
};

vs.

// Without spaces
$scope.addProps = ({prop1, prop2}) => {
  return prop1 + prop2;
};
``` 