### PR TITLE
GitHub update and security update 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules/
 bower_components
 *.sublime-workspace
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "gulp-util": "3.0.8",
     "jscs": "3.0.7",
     "jshint": "2.9.4",
-    "lodash": "4.17.4",
+    "lodash": "4.17.21",
     "log-symbols": "1.0.2",
     "lost": "8.0.0",
     "main-bower-files": "2.13.1",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "postcss-selector-not": "2.0.0",
     "postcss-simple-vars": "3.0.0",
     "q": "1.4.1",
-    "reporter-plus": "git://github.com/jayeb/reporter-plus.git#1.6.0",
+    "reporter-plus": "git+https://github.com/jayeb/reporter-plus.git#1.6.0",
     "semver": "5.3.0",
     "stream-combiner": "0.2.2",
     "stylelint": "4.5.1",


### PR DESCRIPTION
This PR addresses a GH change to remove git:// to be https://

This PR also address a security update for lodash (see screenshot).
<img width="771" alt="Screen Shot 2022-01-11 at 12 25 13 PM" src="https://user-images.githubusercontent.com/13306885/149015936-ba0eb32e-3b1a-4fe6-bb30-4feec8eed0c1.png">

