### PR TITLE
Adds check for heroku using NODE_ENV

### DIFF
--- a/tools/tasks/tasks.build.js
+++ b/tools/tasks/tasks.build.js
@@ -39,7 +39,7 @@ module.exports = function setUpTasks(gulp) {
   gulp.task('build-clean', function buildCleanTask() {
     var destPath = _.get(gulp, 'webToolsConfig.destPath');
 
-    if (destPath) {
+    if (destPath && !_.get(process.env, 'NODE_ENV')) {
       return gulp.src(destPath, {read: false})
         .pipe(clean());
     }


### PR DESCRIPTION
This PR is a supporting PR for upgrading our node versions and heroku image. The `clean()` errors on heroku because it does a fresh install, so we don't need it to run during the build on heroku. So to mitigate this we can check to see if a `NODE_ENV` has been set, since we only set this var on our servers. 