### PR TITLE
Adds new watch feature

### DIFF
--- a/tools/tasks/tasks.watch.js
+++ b/tools/tasks/tasks.watch.js
@@ -28,7 +28,7 @@ module.exports = function setUpTasks(gulp) {
     var watchTasks = _.compact([
       hasAppAssets && 'watch-app',
       hasExtAssets && 'watch-ext',
-      'watch-config'
+      !!args.watch && 'watch-config'
     ]);
 
     return gulp.series(...watchTasks, function finishBuildAppAssets(seriesDone) {


### PR DESCRIPTION
This feature allows engineers to use a watch command to watch server files. Example you'd run `gulp --watch` to use in our static website repos. 

How to test:
- Pull down branch
- Link `web-tools`via `yarn link` in imgix-blog
- Run ` npx gulp --watch`
- Add a console log to server file in imgix-blog
- Watch to see if server re-runs