### PR TITLE
fix: addresses bug where chrome cli was opening new tabs

### DIFF
--- a/tools/misc/chrome-load.js
+++ b/tools/misc/chrome-load.js
@@ -6,49 +6,48 @@ module.exports = function chromeLoad(url) {
   // Check to see if the chrome-cli command exists
   return runCommand('command -v chrome-cli')
     .catch(function throwError(error) {
-        return error;
-      })
+      return error;
+    })
 
-    // List all tabs
-    .then(_.partial(runCommand, 'chrome-cli list links', {encoding: 'utf8'}))
+    // List all tabs in json format
+    .then(_.partial(runCommand, 'OUTPUT_FORMAT=json chrome-cli list links', {encoding: 'utf8'}))
 
     // Filter to tabs matching this URL
     .then(function filterTabs(tabList) {
-        var tabIDs = _.chain(tabList.split('\n'))
-          .map(function reloadTab(tabInfo) {
-              var urlRegex = new RegExp('^\\[(\\d+:?\\d*)\\]\\s' + url.replace('/', '\\/')),
-                  result = urlRegex.exec(tabInfo);
+      const tabIDs = _.chain(JSON.parse(tabList).tabs)
+        .map(function reloadTab(tabInfo) {
+            const isLocalhost = tabInfo.url.includes('localhost');
 
-              if (!!result && result.length) {
-                // [0] is full match, [1] is window & tab id
-                return _.chain(result)
-                  .get('[1]')
-                  .split(':')
-                  .last()
-                  .value();
-              } else {
-                return null;
-              }
-            })
-          .compact()
-          .value();
+            if (isLocalhost) {
+              return tabInfo.id;
+            } else {
+              return null;
+            }
+          })
+        .compact()
+        .value();
 
-        if (tabIDs.length) {
-          return tabIDs;
-        } else {
-          return Q.reject();
-        }
-      })
+      if (tabIDs.length) {
+        return tabIDs;
+      } else {
+        return Q.reject();
+      }
+    })
 
     // If there are tabs, reload them. Otherwise, open a new one
     .then(
-        function reloadTabs(matchingTabIDs) {
-            return Q.all(_.map(matchingTabIDs, function reloadTabByID(tabID) {
-              return runCommand('chrome-cli reload -t ' + tabID);
-            }));
-          },
-        function openNewTab() {
-            return runCommand('chrome-cli open ' + url);
+      function reloadTabs(matchingTabIDs) {
+        return Q.all(_.map(matchingTabIDs, function reloadTabByID(tabID) {
+          // Newer chrome returns negative numbers for ids so we need to check if id is negative
+          if (tabID > 0) {
+            return runCommand('chrome-cli reload -t ' + tabID);
+          } else {
+            return runCommand('chrome-cli reload');
           }
-      );
+        }));
+      },
+      function openNewTab() {
+        return runCommand('chrome-cli open ' + url);
+      }
+    );
 };


### PR DESCRIPTION
This PR fixes a bug where our chrome cli tool was opening new tabs. This is due to a change in new chrome where the IDs are now negative numbers. 

See example of the difference below. Note that one instance im using brave-cli, but take a look at the difference in the ids. This new feature in chrome isnt currently supported in chrome cli, so as a fix we just reload the current tab. which in most cases should be the localhost server. if not you will just need to reload the tab. 

New ids
![Screen Shot 2023-05-12 at 4 01 31 PM](https://github.com/imgix/web-tools/assets/13306885/4aa33e11-0043-4b6a-b18f-91d6c3bc4214)

How is used to be
![Screen Shot 2023-05-12 at 4 01 41 PM](https://github.com/imgix/web-tools/assets/13306885/929b524a-86ec-4917-b711-d3c482f46fff)

This PR also refactors the logic a bit so we dont need to use this confusing regex and instead use built in json format tooling making this module way more understandable imo. 