### PR TITLE
fix: try to access destination path not srv-dev 

### DIFF
--- a/tools/tasks/tasks.build.js
+++ b/tools/tasks/tasks.build.js
@@ -29,7 +29,7 @@ module.exports = function setUpTasks(gulp) {
 
     const destPath = _.get(gulp, 'webToolsConfig.destPath');
 
-    fs.access("./.srv_dev").catch(() => {
+    fs.access(destPath).catch(() => {
       fs.mkdir(destPath, err => {
         if (err) {
           console.log(`Error creating directory ${destPath}`);


### PR DESCRIPTION
# Description
This PR addresses an issue where web-tools would only check that the `.srv_dev` directory did not already exist. It should instead check that the `destPath` doesn't exist, since that's the directory it's going to try to build using `fs.mkdir`.

For example, if you `destBase` was `.serve`, on the first build, web-tools works fine. But on subsequent build commands we'd get an error, `[Error: EEXIST: file already exists, mkdir '.serve']`.

## Steps to test
1. clone branch
2. `nvm use <node version of application you want to link to>
3. `yarn link`
4. switch to application you want to test this version in
5. `yarn link web-tools`
6. Modify the `destinationBase` to be `.serve`
7. run `npx gulp` in the project without clearing out directories