### PR TITLE
fix: dont error when creating nested subdirecotry

### DIFF
--- a/tools/tasks/tasks.build.js
+++ b/tools/tasks/tasks.build.js
@@ -4,7 +4,7 @@ var _ = require('lodash'),
     clean = require('gulp-clean'),
     filter = require('gulp-filter');
 
-const fs = require('fs').promises;
+const fs = require('fs')
 
 
 module.exports = function setUpTasks(gulp) {
@@ -29,14 +29,13 @@ module.exports = function setUpTasks(gulp) {
 
     const destPath = _.get(gulp, 'webToolsConfig.destPath');
 
-    fs.access(destPath).catch(() => {
-      fs.mkdir(destPath, err => {
-        if (err) {
-          console.log(`Error creating directory ${destPath}`);
-
-          throw err;
+    fs.promises.access(destPath).catch(() => {
+        try {
+          fs.mkdirSync(destPath, { recursive: true });
+        } catch (error) {
+          console.error(error);
+          throw new Error(`Failed to create destination directory: ${destPath}`);
         }
-      });
     }).finally(() => {
       runSequence(
         'build-clean',


### PR DESCRIPTION
# Description

This PR replaces `fs.promies` with `fs` "sync" methods where needed. Specifically, `fs.mkdirSync `. By doing so, we no longer error out when a nested directory doesn't exist, instead, we recursively create the directory structure.


## How to test
- clone, link this version of webtools
- change `appDestinationBase` in your project to `.foo/bar/baz`
- make sure that directory does not already exist in your project
- run `npx gulp`
- see your build success with your output files in `.foo/bar/baz/`