### PR TITLE
fix: updates web-tools for using NODE_ENV instead of args for static sites

### DIFF
--- a/tools/pipelines/pipeline.html.js
+++ b/tools/pipelines/pipeline.html.js
@@ -37,7 +37,7 @@ module.exports = function setupHTMLPipeline(gulp) {
       return file.contents.toString();
 
     } else if (ext === '.js') {
-      if (args.env === 'production') {
+      if (process.env.NODE_ENV === 'production') {
         return `<script src="${ filePath }" async defer></script>`;
       } else {
         return `<script src="${ filePath }"></script>`;


### PR DESCRIPTION
This PR changes our args process to use NODE_ENV key instead. This way in our vercel infra we can pass keys for different environments. 

Related to: https://github.com/zebrafishlabs/website_v2/pull/331