### PR TITLE
ci: log instead of error when no chrome-cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-tools",
-  "version": "10.13.1-rc.1",
+  "version": "10.13.0",
   "description": "Repository for tools and configurations common to all imgix web projects",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web-tools",
-  "version": "10.13.0",
+  "version": "10.13.1-rc.1",
   "description": "Repository for tools and configurations common to all imgix web projects",
   "repository": {
     "type": "git",

--- a/tools/misc/chrome-load.js
+++ b/tools/misc/chrome-load.js
@@ -6,7 +6,7 @@ module.exports = function chromeLoad(url) {
   // Check to see if the chrome-cli command exists
   return runCommand('command -v chrome-cli')
     .catch(function throwError(error) {
-      return error;
+      console.error('chrome-cli is not installed. Please install it with `brew install chrome-cli`');
     })
 
     // List all tabs in json format


### PR DESCRIPTION
## Before this PR

Running web-tools in a context where `chrome-cli` was not installed would _throw_ an error.

## After this change
Running web-tools in a context where `chrome-cli` is not installed will _log_ an error.

## More info
This change is needed to stop headless-e2e testing from erroring out whenever testing against the development server on CI.